### PR TITLE
Fixing error with translate button in CV

### DIFF
--- a/src/pages/cv-es.astro
+++ b/src/pages/cv-es.astro
@@ -5,7 +5,7 @@ import TimeLineElement from "../components/cv/TimeLine.astro";
 
 <BaseLayout title="CV en Español" sideBarActiveItemID="cv">
   <div class="relative">
-  <div class="absolute top-1 right-1 z-50 flex gap-3">
+  <div class="absolute top-1 right-1 z-10 flex gap-3">
     <section
       class="
         inline-block px-3 py-2

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -6,7 +6,7 @@ import TimeLineElement from "../components/cv/TimeLine.astro";
 <BaseLayout title="CV in English" sideBarActiveItemID="cv">
   <!--El relative es para ser movido y el z-50 lo uso pa que ponga por encima de posibles elementos que lo tapan -->
   <div class="relative">
-  <div class="absolute top-1 right-1 z-50 flex gap-3">
+  <div class="absolute top-1 right-1 z-10 flex gap-3">
     <section
       class="
         inline-block px-3 py-2

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -67,6 +67,8 @@ const last_posts = posts.slice(0, 3);
     badge=""
   />
   <div>
+
+
     <div class="text-3xl w-full font-bold mb-5 mt-10">Latest from blog</div>
   </div>
 


### PR DESCRIPTION
The button was always in the front, not being able to see other parts of the web page